### PR TITLE
Use miniscript policies and descriptors to describe txo spending policies

### DIFF
--- a/transactions.md
+++ b/transactions.md
@@ -2,6 +2,9 @@
 
 All transactions are version 2 and use version 0 native Segwit scripts.
 
+We use [miniscript](http://bitcoin.sipa.be/miniscript/) and descriptors to generally
+describe outputs spending policies.
+
 We denote `N` the number of participants, `M` the number of managers (the subset
 of the participants allowed to unlock the unvault transaction output along with the
 cosigning servers), and `X` the CSV value in the unvault transaction.
@@ -25,20 +28,11 @@ N/A
 
 #### OUT
 
-At least one output paying to the following (P2WSH) script:
+At least one output paying to `vault_descriptor`, with:
 ```
-0x00 SHA256(<vault_script>)
+vault_descriptor = wsh(vault_witness_script)
+vault_witness_script = thresh(N, pubkey1, pubkey2, ..., pubkeyN)
 ```
-
-With `<vault_script>` being:
-- If `N <= 20`,
-    ```
-    N <pubkey 1> <pubkey 2> ... <pubkey N> N CHECKMULTISIG
-    ```
-- Else,
-    ```
-    <pubkey 1> CHECKSIGVERIFY <pubkey 2> CHECKSIGVERIFY ... <pubkey N> CHECKSIG
-    ```
 
 
 ## unvault_tx
@@ -46,11 +40,6 @@ With `<vault_script>` being:
 The transaction which spends the [`vault_tx`](vault_tx) deposit output, and creates an
 unvault output only spendable by the managers (along with the cosigning servers)
 after `X` blocks.
-
-Note that the `M` pubkeys of the managers are used first in the output script
-for opimisation purpose (they are needed in both spending path anyway).
-
-FIXME(darosior): try miniscript again.
 
 - version: 2
 - locktime: 0
@@ -63,55 +52,34 @@ FIXME(darosior): try miniscript again.
     - vout: N/A
     - sequence: `0xffffffff`
     - scriptSig: `<empty>`
-    - witness:
-        - If `N <= 20`,
-            ```
-            0 <sig pubkey 1> <sig pubkey 2> ... <sig pubkey N> <vault_script>
-            ```
-        - Else,
-            ```
-            <sig pubkey 1> <sig pubkey 2> ... <sig pubkey N> <vault_script>
-            ```
+    - witness: `satisfy(vault_descriptor)`
 
 #### OUT
 
 - count: 2
 - outputs[0]:
-    - value: `<vault_tx output value - tx_fee - 330sats>`
-    - scriptPubkey: `0x00 SHA256(<unvault_script>)`, with `<unvault_script>` being:
-        ```
-        <pubkey 1> CHECKSIGVERIFY ... <pubkey M> CHECKSIGVERIFY
-        IF
-            # The everyone's-signing path, used for pre-signed transactions
-            <pubkey M+1> CHECKSIGVERIFY ... <pubkey N> CHECKSIG
-        ELSE
-            # The managers + cosigning servers path, used by the spend transaction
-            X CHECKSEQUENCEVERIFY DROP
-            <cosigner M+1> CHECKSIGVERIFY ... <cosigner N> CHECKSIG
-        ENDIF
-        ```
-        (Adapted to use `CHECKMULTISIG`s when the number of pubkeys is lesser than or
-        equal to `20`)
+    - value: `<vault_tx output value - tx_fee - 330>`
+    - scriptPubkey: `unvault_descriptor`
 
 - outputs[1]:
-    - value: `330`sats
-    - scriptPubkey: `0x00 SHA256(<cpfp_script>)`, with `<cpfp_script>` being:
-        - If `M < 20`
-            ```
-            M <pubkey 1> <pubkey 2> ... <pubkey M> M CHECKMULTISIG
-            ```
-        - Else,
-            ```
-            <pubkey 1> CHECKSIGVERIFY <pubkey 2> CHECKSIGVERIFY ... <pubkey M> CHECKSIG
-            ```
-        FIXME: do we *really* need a multisig here ? Interaction consequences are
-        cumbersome..
+    - value: `330`
+    - scriptPubkey: `unvault_cpfp_descriptor`
 
+With:
+```
+unvault_descriptor = wsh(unvault_witness_script)
+unvault_witness_script = and(thresh(len(managers), managers), or(1@thresh(len(non_managers), non_managers), 10@and(thresh(len(cosigners), cosigners), older(X))))
+```
+
+```
+unvault_cpfp_descriptor = wsh(unvault_cpfp_witness_script)
+unvault_cpfp_witness_script = thresh(M, pubkey1, pubkey2, ..., pubkeyM)
+```
 
 ## spend_tx
 
-The transaction which spends the unvaulting transaction, only spendable after `X`
-blocks.
+The transaction which spends the unvaulting transaction by the [`M` + cosigners]
+path, only spendable after `X` blocks.
 
 - version: 2
 - locktime: 0
@@ -123,10 +91,7 @@ blocks.
     - txid: `<unvault_tx txid>`
     - sequence: `X`
     - scriptSig: `<empty>`
-    - witness:
-        ```
-        0 <sig pubkey 1> ... <sig pubkey M> 1 <sig cosigner M+1> ... <sig cosigner N> <unvault_script>
-        ```
+    - witness: `satisfy(unvault_descriptor)`
 
 #### OUT
 
@@ -138,8 +103,8 @@ blocks.
 
 ## cancel_tx
 
-This transaction spends the `unvault_tx` and pays back to a vault txout (it's thus another
-deposit transaction).
+This transaction spends the `unvault_tx` using the N-of-N path and pays back to a
+vault txout (it is therefore another deposit transaction).
 
 - version: 2
 - locktime: 0
@@ -152,32 +117,22 @@ deposit transaction).
     - vout: 0
     - sequence: `0xfffffffe`
     - scriptSig: `<empty>`
-    - witness:
-        ```
-        0 <sig pubkey 1>... <sig pubkey M> 0 <sig pubkey M+1> ... <sig pubkey N> <unvault_script>
-        ```
+    - witness: `satisfy(unvault_descriptor)`
 
 #### OUT
 
 - count: 1
 - outputs[0]:
     - value: `<unvault_tx outputs[0] value - tx_fee>`
-    - scriptPubkey: `0x00 SHA256(<vault_script>)`, with `<vault_script>` being:
-        - If `N <= 20`,
-            ```
-            N <pubkey 1> <pubkey 2> ... <pubkey N> N CHECKMULTISIG
-            ```
-        - Else,
-            ```
-            <pubkey 1> CHECKSIGVERIFY <pubkey 2> CHECKSIGVERIFY ... <pubkey N> CHECKSIGVERIFY
-            ```
+    - scriptPubkey: `vault_descriptor`
 
 
 ## emergency_txs
 
 Emergency transactions are used as deterrents against threat. They lock coins to what we
-call an EDV (Emergency Deep Vault): a script chosen by the participants and kept "secret"
-as the emergency transactions are never meant to be used.
+call an EDV (Emergency Deep Vault): a script chosen by the participants and kept
+obfuscated by the properties of P2(W)SH, as the emergency transactions are never meant
+to be used.
 
 
 ### vault_emergency_tx
@@ -195,15 +150,7 @@ This transaction spends the `vault_tx` to the EDV.
     - vout: N/A
     - sequence: `0xfffffffe`
     - scriptSig: `<empty>`
-    - witness:
-        - If `N <= 20`,
-            ```
-            0 <sig pubkey 1> <sig pubkey 2> ... <sig pubkey N> <vault_script>
-            ```
-        - Else,
-            ```
-            <sig pubkey 1> <sig pubkey 2> ... <sig pubkey N> <vault_script>
-            ```
+    - witness: `satisfy(vault_descriptor)`
 
 #### OUT
 
@@ -228,10 +175,7 @@ This transaction spends the `unvault_tx` to the EDV.
     - vout: 0
     - sequence: `0xfffffffe`
     - scriptSig: `<empty>`
-    - witness:
-        ```
-        0 <sig pubkey 1>... <sig pubkey M> 0 <sig pubkey M+1> ... <sig pubkey N> <unvault_script>
-        ```
+    - witness: `satisfy(unvault_descriptor)`
 
 #### OUT
 


### PR DESCRIPTION
This removes the `FIXME: try miniscript (again)` :).

I think this is quite a nice cleanup.