### PR TITLE
Add deposit_outpoints to get_spend_tx

### DIFF
--- a/messages.md
+++ b/messages.md
@@ -352,7 +352,8 @@ return `null`.
 ```json
 {
     "result": {
-        "spend_tx": "base64 of Bitcoin-serialized spend tx"
+        "spend_tx": "base64 of Bitcoin-serialized spend tx",
+        "deposit_outpoints": ["txid:vout", "txid:vout"]
     }
 }
 ```
@@ -361,6 +362,7 @@ or, if the coordinator doesn't have the spend:
 {
     "result": {
         "spend_tx": null,
+        "deposit_outpoints": []
     }
 }
 ```


### PR DESCRIPTION
Adding this new field simplifies greatly
the caching of spend transaction on the
watchtower side.

It is possible to change the API further
by changing `get_spend_tx <deposit_outpoint>`
for `get_spend_txs [<deposit_outpoint>, ...]`